### PR TITLE
Use page_size instead of limit

### DIFF
--- a/src/api/v2/clips.js
+++ b/src/api/v2/clips.js
@@ -3,7 +3,7 @@ const error = require('./util').error
 module.exports = context => {
   const all = async (projectUuid, page, pageSize) => {
     try {
-      const response = await context.get(`projects/${projectUuid}/clips?page=${page}${pageSize ? `&limit=${pageSize}` : ''}`)
+      const response = await context.get(`projects/${projectUuid}/clips?page=${page}${pageSize ? `&page_size=${pageSize}` : ''}`)
       const json = await response.json()
       if (json.success) json.items.map(item => ({
         ...item,

--- a/src/api/v2/projects.js
+++ b/src/api/v2/projects.js
@@ -3,7 +3,7 @@ const error = require('./util').error
 module.exports = context => {
   const all = async (page, pageSize) => {
     try {
-      const response = await context.get(`projects?page=${page}${pageSize ? `&limit=${pageSize}` : ''}`)
+      const response = await context.get(`projects?page=${page}${pageSize ? `&page_size=${pageSize}` : ''}`)
       const json = await response.json()
       if (json.success) json.items.map(item => ({
         ...item,

--- a/src/api/v2/recordings.js
+++ b/src/api/v2/recordings.js
@@ -5,7 +5,7 @@ const FormData = require('form-data')
 module.exports = context => {
   const all = async (voiceUuid, page, pageSize) => {
     try {
-      const response = await context.get(`voices/${voiceUuid}/recordings?page=${page}${pageSize ? `&limit=${pageSize}` : ''}`)
+      const response = await context.get(`voices/${voiceUuid}/recordings?page=${page}${pageSize ? `&page_size=${pageSize}` : ''}`)
       const json = await response.json()
       if (json.success) json.items.map(item => ({
         ...item,

--- a/src/api/v2/voices.js
+++ b/src/api/v2/voices.js
@@ -3,7 +3,7 @@ const error = require('./util').error
 module.exports = context => {
   const all = async (page, pageSize) => {
     try {
-      const response = await context.get(`voices?page=${page}${pageSize ? `&limit=${pageSize}` : ''}`)
+      const response = await context.get(`voices?page=${page}${pageSize ? `&page_size=${pageSize}` : ''}`)
       const json = await response.json()
       if (json.success) json.items.map(item => ({
         ...item,


### PR DESCRIPTION
The v2 API has been updated to accept `page_size` in lieu of `limit`. This PR updates the SDK to use the new query param.