### PR TITLE
feat: add direct synthesis method

### DIFF
--- a/src/resemble.ts
+++ b/src/resemble.ts
@@ -22,6 +22,7 @@ export const Resemble = {
       all: ClipsV2.all,
       createSync: ClipsV2.createSync,
       createAsync: ClipsV2.createAsync,
+      createDirect: ClipsV2.createDirect,
       updateAsync: ClipsV2.updateAsync,
       // stream: ClipsV2.stream,
       get: ClipsV2.get,

--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -36,6 +36,40 @@ export interface AsyncClipInput extends ClipInput {
   callback_uri: string
 }
 
+export interface DirectClipInput {
+  voice_uuid: string
+  project_uuid: string
+  title?: string
+  data: string
+  precision?: 'MULAW' | 'PCM_16' | 'PCM_24' | 'PCM_32'
+  output_format?: 'wav' | 'mp3'
+}
+
+export interface DirectClip {
+  success: true;
+  audio_content: string;
+  audio_timestamps: {
+    graph_chars: string[];
+    graph_times: [number, number][];
+    phon_chars: string[];
+    phon_times: [number, number][];
+  };
+  duration: number;
+  synth_duration: number;
+  output_format: 'wav' | 'mp3';
+  sample_rate: number;
+  issues: string[];
+}
+
+export interface DirectClipError {
+  success: false;
+  issues?: string[];
+  error_name: string;
+  error_params: unknown;
+  feedback_uuid: string;
+  message: string;
+}
+
 export interface StreamInput {
   data: string
   project_uuid: string
@@ -106,6 +140,16 @@ export default {
 
   createSync: async (projectUuid: string, clipInput: SyncClipInput): Promise<WriteResponseV2<Clip> | ErrorResponseV2> => {
     return create(projectUuid, clipInput)
+  },
+
+  createDirect: async (clipInput: DirectClipInput): Promise<DirectClip | DirectClipError | ErrorResponseV2> => {
+    try {
+      const response = await UtilV2.post('synthesize', clipInput, true)
+      let json = await response.json()
+      return json
+    } catch (e) {
+      return UtilV2.errorResponse(e)
+    }
   },
   
   // stream: async function* (streamInput, bufferSize = DEFAULT_BUFFER_SIZE, ignoreWavHeader = true): AsyncGenerator {

--- a/src/v2/util.ts
+++ b/src/v2/util.ts
@@ -39,11 +39,66 @@ export interface ErrorResponseV2 {
   message: string
 }
 
+
 export default {
-  get: (path: string, useSynthesisServer: boolean = false) => fetch((useSynthesisServer ? context.synServerUrl : context.endpoint)('v2', path), { method: 'GET', headers: useSynthesisServer ? context.synthesisServerHeaders() : context.headers() }),
-  post: (path: string, data: Record<string, any> = {}, useSynthesisServer: boolean = false) =>  fetch((useSynthesisServer ? context.synServerUrl : context.endpoint)('v2', path), { method: 'POST', headers: useSynthesisServer ? context.synthesisServerHeaders() : context.headers(), body: JSON.stringify(data) }),
-  put: (path: string, data: Record<string, any> = {}, useSynthesisServer: boolean = false) => fetch((useSynthesisServer ? context.synServerUrl : context.endpoint)('v2', path), { method: 'PUT', headers: useSynthesisServer ? context.synthesisServerHeaders() : context.headers(), body: JSON.stringify(data) }),
-  delete: (path: string, useSynthesisServer: boolean = false) => fetch((useSynthesisServer ? context.synServerUrl : context.endpoint)('v2', path), { method: 'DELETE', headers: useSynthesisServer ? context.synthesisServerHeaders() : context.headers() }),
+  get: (path: string, useSynthesisServer: boolean = false) =>
+    fetch(
+      useSynthesisServer
+        ? context.synServerUrl(path)
+        : context.endpoint("v2", path),
+      {
+        method: "GET",
+        headers: useSynthesisServer
+          ? context.synthesisServerHeaders()
+          : context.headers(),
+      }
+    ),
+  post: (
+    path: string,
+    data: Record<string, any> = {},
+    useSynthesisServer: boolean = false
+  ) =>
+    fetch(
+      useSynthesisServer
+        ? context.synServerUrl(path)
+        : context.endpoint("v2", path),
+      {
+        method: "POST",
+        headers: useSynthesisServer
+          ? context.synthesisServerHeaders()
+          : context.headers(),
+        body: JSON.stringify(data),
+      }
+    ),
+  put: (
+    path: string,
+    data: Record<string, any> = {},
+    useSynthesisServer: boolean = false
+  ) =>
+    fetch(
+      useSynthesisServer
+        ? context.synServerUrl(path)
+        : context.endpoint("v2", path),
+      {
+        method: "PUT",
+        headers: useSynthesisServer
+          ? context.synthesisServerHeaders()
+          : context.headers(),
+        body: JSON.stringify(data),
+      }
+    ),
+  delete: (path: string, useSynthesisServer: boolean = false) =>
+    fetch(
+      useSynthesisServer
+        ? context.synServerUrl(path)
+        : context.endpoint("v2", path),
+      {
+        method: "DELETE",
+        headers: useSynthesisServer
+          ? context.synthesisServerHeaders()
+          : context.headers(),
+      }
+    ),
 
   errorResponse: (e: any): ErrorResponseV2 => ({
     success: false,


### PR DESCRIPTION
This adds a way to use the 'Direct Synthesis API' to the SDK.

I've also cleaned up the `utils.ts` `fetch` requests as the code was hard to read on a single line. (I recommend the [Prettier](https://prettier.io/) tool for this!)

The docs at https://docs.app.resemble.ai/docs/direct_synthesis should also be corrected with the following:

- Under `HTTP Response` change `phoneme_timestamps` to `audio_timestamps`, which should look like this:

```ts
{
    graph_chars: string[];
    graph_times: [number, number][];
    phon_chars: string[];
    phon_times: [number, number][];
}
```

- Under `Response Body` change `phoneme_timestamps` to `audio_timestamps`
- Under `Response Body`, lowercase `issues` and `success`, and consider adding the following missing fields:

```
{
    duration: number;
    synth_duration: number;
    output_format: 'wav' | 'mp3';
    sample_rate: number;
}
```

- Under `Audio Timestamps Object`, fix this table (it's currently jumbled up)

Let me know if you'd like any edits made! 🙂 