### PR TITLE
Add `exports.types` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {
+    "types": "./dist/resemble.d.ts",
     "require": "./dist/resemble.cjs",
     "default": "./dist/resemble.modern.js"
   },


### PR DESCRIPTION
To support `"moduleResolution": "node16"` in TypeScript. Without this, you get the following error:

```There are types at '<PROJECT_DIR>/node_modules/@resemble/node/dist/resemble.d.ts', but this result could not be resolved when respecting package.json "exports". The '@resemble/node' library may need to update its package.json or typings.```