### PR TITLE
Add timestamps support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {

--- a/src/v2/StreamDecoder.ts
+++ b/src/v2/StreamDecoder.ts
@@ -4,6 +4,7 @@ export const STREAMING_WAV_HEADER_BUFFER_LEN = 44
 export const StreamDecoder = function (
   bufferSize = DEFAULT_BUFFER_SIZE,
   ignoreWavHeader = true,
+  timeStampsProcessingRequired = false,
 ) {
   if (bufferSize < 2) throw new Error('Buffer size cannot be less than 2')
   if (bufferSize % 2 !== 0)
@@ -12,6 +13,11 @@ export const StreamDecoder = function (
   this.ignoreWavHeader = ignoreWavHeader
   this.chunks = []
   this.headerBuffer = Buffer.from('')
+
+  this.processTimeStamps = timeStampsProcessingRequired
+  this.timeStampsBuffer = []
+  this.allTimestampsProcessed = false
+  this.timeStamps = {}
 }
 
 StreamDecoder.prototype.setBufferSize = function (size) {
@@ -25,19 +31,58 @@ StreamDecoder.prototype.setIgnoreWavHeader = function (val) {
   this.ignoreWavHeader = val
 }
 
-StreamDecoder.prototype.decodeChunk = function (chunk) {
+StreamDecoder.prototype.decodeChunk = function (chunk: Uint8Array) {
+  // 1. User wants headers. no timestamps have been requested, we can store the chunks as they come
   this.chunks.push(chunk)
+  if (this.processTimeStamps && !this.allTimestampsProcessed) {
+    this.timeStampsBuffer.push(chunk)
+  }
+
+  // 2. user does not need headers and timestamps are also not present, so we ignore the 44 bytes (wav header size) and return the rest
   if (
-    this.headerBuffer.length < STREAMING_WAV_HEADER_BUFFER_LEN &&
-    this.ignoreWavHeader
+    this.headerBuffer.length < STREAMING_WAV_HEADER_BUFFER_LEN && // check if header has been processed
+    this.ignoreWavHeader && // Check if header should be ignored
+    !this.processTimeStamps
   ) {
     const tempBuf = Buffer.concat(this.chunks)
     if (tempBuf.length >= STREAMING_WAV_HEADER_BUFFER_LEN) {
-      this.headerBuffer = tempBuf.slice(0, STREAMING_WAV_HEADER_BUFFER_LEN)
-      const tempDataBuffer = tempBuf.slice(STREAMING_WAV_HEADER_BUFFER_LEN)
+      this.headerBuffer = tempBuf.slice(0, STREAMING_WAV_HEADER_BUFFER_LEN) // Extract header, for next set of chunks to ignore
+      const tempDataBuffer = tempBuf.slice(STREAMING_WAV_HEADER_BUFFER_LEN) // Extract data
 
       this.chunks = []
-      this.chunks.push(tempDataBuffer)
+      this.chunks.push(tempDataBuffer) // set the chunks with the data
+    }
+  }
+
+  // 3. user wants timestamps and headers too: process the timestamps
+  if (!this.ignoreWavHeader && this.processTimeStamps) {
+    if (!this.allTimestampsProcessed) {
+      const tempBuf = Buffer.concat(this.timeStampsBuffer)
+      const obj = extractTimestampsFromBuffer(tempBuf)
+
+      if (obj.timestamps && obj.timestamps !== null) {
+        this.timeStamps = obj.timestamps
+        this.allTimestampsProcessed = true
+        this.timeStampsBuffer = []
+      }
+    }
+  }
+
+  // 4. timestamps are present and have been requested but no headers are wanted: process the timestamps and ignore wav header + timestamps chunks
+  if (this.ignoreWavHeader && this.processTimeStamps) {
+    // TODO: fix headers deletion
+    if (!this.allTimestampsProcessed) {
+      const tempBuf = Buffer.concat(this.timeStampsBuffer)
+      const obj = extractTimestampsFromBuffer(tempBuf)
+
+      if (obj.timestamps && obj.timestamps !== null) {
+        this.timeStamps = obj.timestamps
+        this.allTimestampsProcessed = true
+        const tempBuf = Buffer.concat(this.timeStampsBuffer)
+        const tempDataBuffer = tempBuf.slice(obj.offset)
+        this.chunks = []
+        this.chunks.push(tempDataBuffer)
+      }
     }
   }
 }
@@ -61,4 +106,108 @@ StreamDecoder.prototype.flushBuffer = function (force = false) {
 StreamDecoder.prototype.reset = function () {
   this.chunks = []
   this.headerBuffer = Buffer.from('')
+}
+
+StreamDecoder.prototype.getTimestamps = function () {
+  if (this.processTimeStamps && this.allTimestampsProcessed) {
+    return this.timeStamps
+  }
+  return null
+}
+
+function extractTimestampsFromBuffer(buffer: Buffer) {
+  let offset = 0
+  offset += 4 // Skip RIFF ID
+
+  offset += 4 // skip remaining file size
+  offset += 14 // skp RIFF type (WAVE), format chunk id, chunk data size, and compression code
+
+  let [nChannels, sampleRate] = [
+    buffer.readUInt16LE(offset), // read number of channels
+    buffer.readUInt32LE(offset + 2), // and sample rate
+  ]
+  offset += 14 // skip byte rate, block align and bits per sample at this point we have covered the Header & Format chunks: https://docs.app.resemble.ai/docs/resource_clip/stream#header--format-chunks
+
+  let chunkType = buffer.toString('ascii', offset, offset + 4) // now we are at Timestamps (cue, list & ltxt chunks): https://docs.app.resemble.ai/docs/resource_clip/stream#timestamps-cue-list--ltxt-chunks
+
+  offset += 4
+  const timestamps = {
+    graph_chars: [],
+    graph_times: [],
+    phon_chars: [],
+    phon_times: [],
+  }
+
+  if (chunkType === 'cue ') {
+    let [remSize, nCuePoints] = [
+      buffer.readUInt32LE(offset), // Remaining size of the cue chunk
+      buffer.readUInt32LE(offset + 4), // Number of remaining cue points
+    ]
+    offset += 8 // skip to the first cue point
+    let endPoint = offset + remSize - 4 // we subtract 4 to account for the "n_cue_points" field size
+
+    let cuePoints = {}
+
+    // start from the first cue point and read all cue points
+    // each cue point is 24 bytes long
+
+    if (endPoint > buffer.length) {
+      return { timestamps: null, offset }
+    }
+    for (let cp = 1; cp <= nCuePoints; cp++) {
+      const idx = buffer.readUInt32LE(offset)
+      const cuePoint = buffer.readUInt32LE(offset + 20)
+      cuePoints[idx] = cuePoint
+      offset += 24
+    }
+
+    // now the offset is at the beginning of the LIST chunk, remember we are processing in the little-endian order
+    chunkType = buffer.toString('ascii', offset, offset + 4) // read the LIST chunk type
+    remSize = buffer.readUInt32LE(offset + 4)
+    offset += 12 // arrive at the start of first LTXT chunk
+
+    let listEndPoint = offset + remSize - 4 // we subtract 4 to account for the "rem size" field
+
+    if (listEndPoint > buffer.length) {
+      return { timestamps: null, offset }
+    }
+
+    // start from the first LTXT chunk and read all LTXT chunks
+    while (offset < listEndPoint) {
+      const subChunkSize = buffer.readUInt32LE(offset + 4) // Remaining size of this ltxt chunk after this read
+      const cueIdx = buffer.readUInt32LE(offset + 8)
+      const nSamples = buffer.readUInt32LE(offset + 12)
+      let charTypeRaw = buffer.toString('ascii', offset + 16, offset + 20) // "grph" OR "phon"
+      let charType = charTypeRaw.trim()
+
+      offset += 28
+
+      const textLen = subChunkSize - 20
+      const text = buffer.toString('utf-8', offset, offset + textLen - 1) // -1 to remove the null character at the end
+
+      offset += textLen
+      offset += textLen % 2
+
+      const typeMapping = {
+        grph: 'graph',
+        phon: 'phon',
+      }
+      let mappedType = typeMapping[charType]
+
+      timestamps[`${mappedType}_chars`].push(text)
+      timestamps[`${mappedType}_times`].push([
+        cuePoints[cueIdx] / sampleRate,
+        (cuePoints[cueIdx] + nSamples) / sampleRate,
+      ])
+    }
+
+    return {
+      timestamps: timestamps,
+      offset,
+    }
+  } else {
+    return {
+      timestamps: null,
+    }
+  }
 }

--- a/src/v2/StreamDecoder.ts
+++ b/src/v2/StreamDecoder.ts
@@ -118,7 +118,7 @@ StreamDecoder.prototype.decodeChunk = function (chunk: Uint8Array) {
     }
   }
 
-  // 4. TODO: timestamps are present and have been requested but no headers are wanted
+  // 4. timestamps are present and have been requested but no headers are wanted
   if (this.ignoreWavHeader && this.processTimeStamps) {
     if (!this.allTimestampsProcessed) {
       const tempBuf = Buffer.concat(this.timeStampsBuffer)

--- a/src/v2/StreamDecoder.ts
+++ b/src/v2/StreamDecoder.ts
@@ -125,7 +125,7 @@ StreamDecoder.prototype.decodeChunk = function (chunk: Uint8Array) {
       const obj = this.extractTimestampsFromBuffer(tempBuf)
 
       if (!obj.timestamps && obj.offset) {
-        // delete the bytes upto the offset from the chunks about to be flushed
+        // we haven't reached the data section yet, discard evrything
         this.chunks = []
       }
 

--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -185,9 +185,14 @@ export default {
     },
     bufferSize = DEFAULT_BUFFER_SIZE,
     ignoreWavHeader = true,
+    wav_encoded_timestamps = false,
   ): AsyncGenerator {
     try {
-      const response = await UtilV2.post('stream', streamInput, true)
+      const response = await UtilV2.post(
+        'stream',
+        { ...streamInput, wav_encoded_timestamps },
+        true,
+      )
 
       // check for error response
       if (!response.ok || !response.body) {

--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -80,6 +80,12 @@ export interface StreamInput {
   voice_uuid: string
 }
 
+export interface StreamConfig {
+  bufferSize?: number
+  ignoreWavHeader?: boolean
+  getTimeStamps?: boolean
+}
+
 const create = async (projectUuid: string, clipInput: ClipInput) => {
   try {
     const response = await UtilV2.post(
@@ -178,19 +184,29 @@ export default {
   },
 
   stream: async function* (
-    streamInput: {
-      data: string
-      project_uuid: string
-      voice_uuid: string
-    },
-    bufferSize = DEFAULT_BUFFER_SIZE,
-    ignoreWavHeader = true,
-    getTimeStamps = false,
+    streamInput: StreamInput,
+    streamConfig: StreamConfig | undefined,
   ): AsyncGenerator {
+    const defaultStreamConfig = {
+      bufferSize: DEFAULT_BUFFER_SIZE,
+      ignoreWavHeader: false,
+      getTimeStamps: false,
+    }
+
+    const getTimeStamps =
+      streamConfig?.getTimeStamps || defaultStreamConfig.getTimeStamps
+    const bufferSize =
+      streamConfig?.bufferSize || defaultStreamConfig.bufferSize
+    const ignoreWavHeader =
+      streamConfig?.ignoreWavHeader || defaultStreamConfig.ignoreWavHeader
+
     try {
       const response = await UtilV2.post(
         'stream',
-        { ...streamInput, wav_encoded_timestamps: getTimeStamps },
+        {
+          ...streamInput,
+          wav_encoded_timestamps: getTimeStamps,
+        },
         true,
       )
 


### PR DESCRIPTION
Hi @TediPapajorgji. Can you review this pull request that will wav_encoded_timestamps as an argument to the Resemble.v2.clips.stream function and also add wav_encoded_timestamps to the body of the streaming API request?

Should I also bump the version when I make a change like this?

