### PR TITLE
bump package version due to npm unpublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {


### PR DESCRIPTION
- accidentally published wrong build to npm. had to unpublish v3.2.0. No users were affected by this.