### PR TITLE
fix stream input type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {

--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -78,6 +78,8 @@ export interface StreamInput {
   data: string
   project_uuid: string
   voice_uuid: string
+  sample_rate?: 8000 | 16000 | 22050 | 44100 | 32000
+  precision?: 'MULAW' | 'PCM_16' | 'PCM_32'
 }
 
 export interface StreamConfig {


### PR DESCRIPTION
added the missing optional types to StreamInput param

```js
export interface StreamInput {
  data: string
  project_uuid: string
  voice_uuid: string
  sample_rate?: 8000 | 16000 | 22050 | 44100 | 32000
  precision?: 'MULAW' | 'PCM_16' | 'PCM_32'
}
```