### PR TITLE
feat: make streaming work in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@resemble/node",
-  "version": "3.0.0",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@resemble/node",
-      "version": "3.0.0",
+      "version": "3.4.0",
       "dependencies": {
         "dotenv": "^16.3.1",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@resemble/node",
   "description": "Resemble API",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "type": "module",
   "source": "src/resemble.ts",
   "exports": {

--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -254,7 +254,7 @@ export default {
       // Keep draining the buffer until the buffer.length < bufferSize or buffer.length == 0
       let buffer = streamDecoder.flushBuffer()
       while (buffer !== null) {
-        const buffToReturn = Buffer.from(buffer)
+        const buffToReturn = new Uint8Array(buffer)
         buffer = streamDecoder.flushBuffer()
         yield {
           data: buffToReturn,

--- a/src/v2/util.ts
+++ b/src/v2/util.ts
@@ -105,3 +105,26 @@ export default {
     message: `Library error: ${e}`,
   }),
 }
+
+// https://github.com/sindresorhus/uint8array-extras
+
+export function concatUint8Arrays(arrays: Uint8Array[], totalLength?: number) {
+  if (arrays.length === 0) {
+    return new Uint8Array(0)
+  }
+
+  totalLength ??= arrays.reduce(
+    (accumulator, currentValue) => accumulator + currentValue.length,
+    0,
+  )
+
+  const returnValue = new Uint8Array(totalLength)
+
+  let offset = 0
+  for (const array of arrays) {
+    returnValue.set(array, offset)
+    offset += array.length
+  }
+
+  return returnValue
+}


### PR DESCRIPTION
- migrated from `Buffer` to `Uint8Array` as typed arrays are available in both browsers and node