### PR TITLE
Remove is_public field

### DIFF
--- a/src/v2/clips.ts
+++ b/src/v2/clips.ts
@@ -11,7 +11,6 @@ export interface Clip {
   title: string
   body: string
   voice_uuid: string
-  is_public: boolean
   is_archived: boolean
   timestamps?: any
   audio_src?: string
@@ -24,7 +23,6 @@ interface ClipInput {
   title?: string
   body: string
   voice_uuid: string
-  is_public: boolean
   is_archived: boolean
   sample_rate?: 16000 | 22050 | 44100
   output_format?: 'wav' | 'mp3'

--- a/src/v2/projects.ts
+++ b/src/v2/projects.ts
@@ -11,7 +11,6 @@ export interface Project {
   uuid: string
   name: string
   description: string
-  is_public: boolean
   is_collaborative: boolean
   is_archived: boolean
   created_at: Date
@@ -21,7 +20,6 @@ export interface Project {
 export interface ProjectInput {
   name: string
   description: string
-  is_public: boolean
   is_collaborative: boolean
   is_archived: boolean
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -72,7 +72,6 @@ test('projects', async () => {
     description: 'SDK Test Description',
     is_archived: false,
     is_collaborative: false,
-    is_public: false,
   })
   expect(project.success).toEqual(true)
   const updated_project = await Resemble.v2.projects.update(project.item.uuid, {
@@ -92,7 +91,6 @@ test('clips', async () => {
     description: 'Test Description',
     is_archived: false,
     is_collaborative: false,
-    is_public: false,
   })
   const projectUuid = project.item.uuid
 
@@ -102,7 +100,6 @@ test('clips', async () => {
     voice_uuid: getTestVoiceUUID(),
     body: 'This is a test',
     is_archived: false,
-    is_public: false,
   })
 
   expect(syncClip.success).toEqual(true)


### PR DESCRIPTION
Today, if you create a project or clip without the `is_public` field, said resource will be created successfully. The reason is because their respective v2 controller have ways to handle the POST request even if the field is absent.

It does not appear the field is used as well. It is time to remove it now.